### PR TITLE
chore(algo): désactiver ITE fret en attente validation Cerema

### DIFF
--- a/.claude/context/evaluation-patterns.md
+++ b/.claude/context/evaluation-patterns.md
@@ -81,9 +81,10 @@ OrchestrateurService.calculerMutabilite()
 
 ## Algorithme de scoring
 
-### Matrice 28 critères × 7 usages
+### Matrice 27 critères × 7 usages
 
-L'algorithme évalue 28 critères pour chacun des 7 usages possibles d'une friche.
+L'algorithme évalue 27 critères pour chacun des 7 usages possibles d'une friche.
+Note : `distanceIte` (poids 0.5) est temporairement désactivé en attente de validation Cerema.
 
 #### Les 7 usages
 
@@ -105,13 +106,13 @@ POSITIF      = 1
 TRES_POSITIF = 2
 ```
 
-#### Les 28 critères (18 enrichis + 10 complémentaires)
+#### Les 27 critères (17 enrichis + 10 complémentaires)
 
 > Source de vérité : `POIDS_CRITERES` dans `algorithme.config.ts`. La répartition
 > enrichis/complémentaires suit `DonneesComplementairesInputDto` (champs saisis par
 > l'utilisateur).
 
-**Enrichis automatiquement** (poids total : 18.5) :
+**Enrichis automatiquement** (poids total : 18) :
 
 | Critère | Poids | Type |
 |---------|-------|------|
@@ -132,7 +133,7 @@ TRES_POSITIF = 2
 | `zonagePatrimonial` | 1 | Enum (3 valeurs) |
 | `zoneAccelerationEnr` | 1 | Enum (3 valeurs) |
 | `zonageAbcLogement` | 0.5 | Enum (A / Abis / B1 / B2 / C) |
-| `distanceIte` | 0.5 | Enum (<1km bon état / <1km mauvais état / >1km) |
+| ~~`distanceIte`~~ | ~~0.5~~ | ~~Enum (<1km bon état / <1km mauvais état / >1km)~~ — **désactivé temporairement** |
 
 **Complémentaires manuels** (poids total : 11.5) :
 
@@ -149,7 +150,7 @@ TRES_POSITIF = 2
 | `presenceEspecesProtegees` | 1 | Enum (Oui / Non / Ne sait pas) |
 | `presenceZoneHumide` | 1 | Enum (Oui / Non / Ne sait pas) |
 
-**Poids total : 30**
+**Poids total : 29.5**
 
 ### Formule de calcul
 

--- a/apps/api/src/enrichissement/services/enrichissement.service.spec.ts
+++ b/apps/api/src/enrichissement/services/enrichissement.service.spec.ts
@@ -248,7 +248,8 @@ describe("EnrichissementService", () => {
       expect(result.codeInsee).toBe("29232");
       expect(result.commune).toBe("Quimper");
       expect(result.surfaceSite).toBe(1000);
-      expect(result.sourcesUtilisees).toHaveLength(11);
+      // ITE fret désactivé temporairement (était 11 avec ITE)
+      expect(result.sourcesUtilisees).toHaveLength(10);
     });
 
     it("devrait persister l'enrichissement avec statut SUCCES", async () => {

--- a/apps/api/src/enrichissement/services/enrichissement.service.ts
+++ b/apps/api/src/enrichissement/services/enrichissement.service.ts
@@ -140,9 +140,9 @@ export class EnrichissementService {
         sourcesEchouees,
       );
 
-      // 3.b ITE FRET (Installations Terminales Embranchées fret)
-      const iteFretResult = await this.iteFretEnrichissement.enrichir(siteEval);
-      this.mergeEnrichmentResult(iteFretResult, sourcesUtilisees, champsManquants, sourcesEchouees);
+      // 3.b ITE FRET — désactivé, en attente validation Cerema
+      // const iteFretResult = await this.iteFretEnrichissement.enrichir(siteEval);
+      // this.mergeEnrichmentResult(iteFretResult, sourcesUtilisees, champsManquants, sourcesEchouees);
 
       // 4. URBANISME (commerces, logements vacants, centre-ville)
       const urbanismeResult = await this.urbanismeEnrichissement.enrichir(siteEval);
@@ -247,7 +247,7 @@ export class EnrichissementService {
         siteEnCentreVille: siteEval.siteEnCentreVille,
         distanceAutoroute: siteEval.distanceAutoroute,
         distanceTransportCommun: siteEval.distanceTransportCommun,
-        distanceIte: siteEval.distanceIte,
+        // distanceIte: siteEval.distanceIte, // Désactivé — en attente validation Cerema
         proximiteCommercesServices: siteEval.proximiteCommercesServices,
         tauxLogementsVacants: siteEval.tauxLogementsVacants,
         presenceRisquesTechnologiques: siteEval.presenceRisquesTechnologiques,
@@ -405,9 +405,9 @@ export class EnrichissementService {
         sourcesEchouees,
       );
 
-      // 4.b ITE FRET -> centroïde du site
-      const iteFretResult = await this.iteFretEnrichissement.enrichir(siteEval);
-      this.mergeEnrichmentResult(iteFretResult, sourcesUtilisees, champsManquants, sourcesEchouees);
+      // 4.b ITE FRET — désactivé, en attente validation Cerema
+      // const iteFretResult = await this.iteFretEnrichissement.enrichir(siteEval);
+      // this.mergeEnrichmentResult(iteFretResult, sourcesUtilisees, champsManquants, sourcesEchouees);
 
       // 5. URBANISME -> LOVAC: commune prédominante, BPE: centroïde
       const urbanismeResult = await this.urbanismeEnrichissement.enrichir(siteEval);
@@ -524,7 +524,7 @@ export class EnrichissementService {
         siteEnCentreVille: siteEval.siteEnCentreVille,
         distanceAutoroute: siteEval.distanceAutoroute,
         distanceTransportCommun: siteEval.distanceTransportCommun,
-        distanceIte: siteEval.distanceIte,
+        // distanceIte: siteEval.distanceIte, // Désactivé — en attente validation Cerema
         proximiteCommercesServices: siteEval.proximiteCommercesServices,
         tauxLogementsVacants: siteEval.tauxLogementsVacants,
         presenceRisquesTechnologiques: siteEval.presenceRisquesTechnologiques,

--- a/apps/api/src/evaluation/services/algorithme/algorithme.config.spec.ts
+++ b/apps/api/src/evaluation/services/algorithme/algorithme.config.spec.ts
@@ -11,8 +11,9 @@ import { NOMBRE_CRITERES_UTILISES } from "./algorithme.constants";
  * l'algorithme »). Mettre à jour les valeurs attendues ci-dessous ET la doc.
  */
 describe("POIDS_CRITERES — cohérence avec la doc de l'algorithme", () => {
-  const NOMBRE_CRITERES_ATTENDU = 28;
-  const POIDS_TOTAL_ATTENDU = 30;
+  // distanceIte (0.5) désactivé temporairement — en attente validation Cerema
+  const NOMBRE_CRITERES_ATTENDU = 27;
+  const POIDS_TOTAL_ATTENDU = 29.5;
 
   it(`comporte exactement ${NOMBRE_CRITERES_ATTENDU} critères`, () => {
     expect(NOMBRE_CRITERES_UTILISES).toBe(NOMBRE_CRITERES_ATTENDU);

--- a/apps/api/src/evaluation/services/algorithme/algorithme.config.ts
+++ b/apps/api/src/evaluation/services/algorithme/algorithme.config.ts
@@ -16,15 +16,15 @@ import {
   ZonageReglementaire,
   ZoneAccelerationEnr,
   ZonageAbcLogement,
-  DistanceIte,
 } from "@mutafriches/shared-types";
 import { ScoreImpact, ScoreParUsage } from "./algorithme.types";
 
 // Configuration des poids
-// 28 critères au total, poids total = 30 (source de vérité de la doc de l'algo)
+// 27 critères au total, poids total = 29.5 (source de vérité de la doc de l'algo)
+// Note : distanceIte (0.5) désactivé temporairement — en attente validation Cerema
 export const POIDS_CRITERES = {
   // ------------------------------------------------
-  // 18 critères enrichis automatiquement (module enrichissement) — poids 18.5
+  // 17 critères enrichis automatiquement (module enrichissement) — poids 18
   // ------------------------------------------------
   surfaceSite: 2,
   surfaceBati: 2,
@@ -43,7 +43,7 @@ export const POIDS_CRITERES = {
   zonagePatrimonial: 1,
   zoneAccelerationEnr: 1,
   zonageAbcLogement: 0.5,
-  distanceIte: 0.5,
+  // distanceIte: 0.5, // Désactivé — en attente validation Cerema
 
   // ------------------------------------------------
   // 10 critères saisis (données complémentaires utilisateur) — poids 11.5
@@ -1157,34 +1157,6 @@ export const MATRICE_SCORING = {
     },
   },
 
-  // Distance à une Installation Terminale Embranchée (ITE) fret
-  distanceIte: {
-    [DistanceIte.MOINS_1KM_BON_ETAT]: {
-      [UsageType.RESIDENTIEL]: ScoreImpact.NEUTRE,
-      [UsageType.EQUIPEMENTS]: ScoreImpact.NEUTRE,
-      [UsageType.CULTURE]: ScoreImpact.NEUTRE,
-      [UsageType.TERTIAIRE]: ScoreImpact.NEUTRE,
-      [UsageType.INDUSTRIE]: ScoreImpact.TRES_POSITIF,
-      [UsageType.RENATURATION]: ScoreImpact.NEUTRE,
-      [UsageType.PHOTOVOLTAIQUE]: ScoreImpact.NEUTRE,
-    },
-    [DistanceIte.MOINS_1KM_MAUVAIS_ETAT]: {
-      [UsageType.RESIDENTIEL]: ScoreImpact.NEUTRE,
-      [UsageType.EQUIPEMENTS]: ScoreImpact.NEUTRE,
-      [UsageType.CULTURE]: ScoreImpact.NEUTRE,
-      [UsageType.TERTIAIRE]: ScoreImpact.NEUTRE,
-      [UsageType.INDUSTRIE]: ScoreImpact.POSITIF,
-      [UsageType.RENATURATION]: ScoreImpact.NEUTRE,
-      [UsageType.PHOTOVOLTAIQUE]: ScoreImpact.NEUTRE,
-    },
-    [DistanceIte.PLUS_1KM]: {
-      [UsageType.RESIDENTIEL]: ScoreImpact.NEUTRE,
-      [UsageType.EQUIPEMENTS]: ScoreImpact.NEUTRE,
-      [UsageType.CULTURE]: ScoreImpact.NEUTRE,
-      [UsageType.TERTIAIRE]: ScoreImpact.NEUTRE,
-      [UsageType.INDUSTRIE]: ScoreImpact.NEUTRE,
-      [UsageType.RENATURATION]: ScoreImpact.NEUTRE,
-      [UsageType.PHOTOVOLTAIQUE]: ScoreImpact.NEUTRE,
-    },
-  },
+  // Distance ITE fret — désactivé, en attente validation Cerema
+  // distanceIte: { ... }
 } as const;

--- a/apps/api/src/evaluation/services/algorithme/versions/index.ts
+++ b/apps/api/src/evaluation/services/algorithme/versions/index.ts
@@ -68,7 +68,7 @@ export const ALGORITHME_VERSIONS: AlgorithmeConfig[] = [
   },
   {
     version: "v1.9",
-    label: "v1.8 + corrections PV (version actuelle)",
+    label: "v1.7 + corrections PV (version actuelle, sans ITE fret)",
     date: "2026-05-21",
     poidsCriteres: v19.POIDS_CRITERES as unknown as Record<string, number>,
     matriceScoring: v19.MATRICE_SCORING as unknown as Record<string, unknown>,

--- a/apps/api/src/evaluation/services/calcul.service.ts
+++ b/apps/api/src/evaluation/services/calcul.service.ts
@@ -344,10 +344,10 @@ export class CalculService {
       criteres.zonageAbcLogement = site.zonageAbcLogement;
     }
 
-    // Distance à une ITE fret (v1.8+)
-    if (!poidsCriteres || "distanceIte" in poidsCriteres) {
-      criteres.distanceIte = site.distanceIte;
-    }
+    // Distance ITE fret — désactivé, en attente validation Cerema
+    // if (!poidsCriteres || "distanceIte" in poidsCriteres) {
+    //   criteres.distanceIte = site.distanceIte;
+    // }
 
     return criteres;
   }

--- a/apps/ui/src/features/debug/components/sections/EnrichissementSection.tsx
+++ b/apps/ui/src/features/debug/components/sections/EnrichissementSection.tsx
@@ -43,8 +43,7 @@ export const EnrichissementSection: React.FC<EnrichissementSectionProps> = ({
         <dt>Distance transport en commun</dt>
         <dd>{formatDistance(enrichmentData.distanceTransportCommun)}</dd>
 
-        <dt>Distance ITE fret</dt>
-        <dd>{enrichmentData.distanceIte ?? "Non disponible"}</dd>
+        {/* Distance ITE fret — désactivé, en attente validation Cerema */}
 
         <dt>Commerces / services</dt>
         <dd>

--- a/apps/ui/src/features/qualification/pages/QualificationEnvironnementPage.tsx
+++ b/apps/ui/src/features/qualification/pages/QualificationEnvironnementPage.tsx
@@ -254,25 +254,7 @@ export const QualificationEnvironnementPage: React.FC = () => {
             tooltip="Indiquez la qualité de la desserte du site par les voies de circulation."
           />
 
-          <EnrichedInfoField
-            id="distance-ite-fret"
-            label="Distance à une installation de chargement industrielle"
-            value={uiData?.distanceIte}
-            tooltip={
-              <>
-                Récupéré depuis la base ITE 3000 du Cerema (Installations Terminales Embranchées
-                fret) :<br />
-                <a
-                  href="https://www.data.gouv.fr/datasets/base-de-donnees-des-installations-terminales-embranchees-fret-en-france-ite-3000"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="fr-link fr-text--xs"
-                >
-                  data.gouv.fr/datasets/base-ite-3000
-                </a>
-              </>
-            }
-          />
+          {/* Distance ITE fret — désactivé, en attente validation Cerema */}
         </div>
 
         <hr className="fr-my-4w" />

--- a/apps/ui/src/features/resultats/utils/dynamicTags/config.ts
+++ b/apps/ui/src/features/resultats/utils/dynamicTags/config.ts
@@ -13,7 +13,6 @@ import {
   QualitePaysage,
   QualiteVoieDesserte,
   RaccordementEau,
-  DistanceIte,
 } from "@mutafriches/shared-types";
 import { TagInputData, UsageTagsConfig } from "./types";
 import {
@@ -354,12 +353,9 @@ const resolveZonageAbcLogement = (data: TagInputData): string | null => {
   return zonage === "abis" || zonage === "a" ? "Zone A logement" : null;
 };
 
-// --- Accès au fret ferroviaire (ITE) ---
-// Tag informationnel affiché si une ITE en bon état est à moins d'1 km du site,
-// quel que soit l'usage. L'algorithme ne valorise ce critère que pour Industrie
-// (TRES_POSITIF), mais le tag reste utile à afficher pour les autres usages.
-const resolveAccesFret = (data: TagInputData): string | null => {
-  return data.enrichmentData.distanceIte === DistanceIte.MOINS_1KM_BON_ETAT ? "accès Fret" : null;
+// --- Accès au fret ferroviaire (ITE) — désactivé, en attente validation Cerema ---
+const resolveAccesFret = (_data: TagInputData): string | null => {
+  return null;
 };
 
 // ============================================================================

--- a/docs/evaluation-mutabilite.md
+++ b/docs/evaluation-mutabilite.md
@@ -13,7 +13,7 @@
 
 Mutafriches est un algorithme d'aide à la décision qui évalue le potentiel de reconversion d'une friche urbaine.
 
-Il analyse **28 critères** pour déterminer le meilleur usage futur parmi **7 possibilités**, en produisant :
+Il analyse **27 critères** pour déterminer le meilleur usage futur parmi **7 possibilités**, en produisant :
 
 - Un **indice de mutabilité** (0-100%) pour chaque usage
 - Un **classement** des usages par ordre de pertinence
@@ -46,9 +46,9 @@ Il analyse **28 critères** pour déterminer le meilleur usage futur parmi **7 p
  ┌─────────────┐         ┌─────────────┐          ┌─────────────┐
  │  COLLECTE   │         │ CONSULTATION│          │   CALCUL    │
  │     DES     │  ────→  │   MATRICE   │  ────→   │     DES     │
- │  28 CRITÈRES│         │  DE SCORING │          │   POINTS    │
+ │  27 CRITÈRES│         │  DE SCORING │          │   POINTS    │
  └─────────────┘         └─────────────┘          └─────────────┘
-  État friche             28 critères ×            Score × Poids
+  État friche             27 critères ×            Score × Poids
   Situation               7 usages =               Pour chaque
   Réglementation          196 valeurs              usage
   Patrimoine              
@@ -76,24 +76,24 @@ Il analyse **28 critères** pour déterminer le meilleur usage futur parmi **7 p
 
 ### Étape 1 : Collecte des données
 
-L'algorithme collecte **28 critères** répartis en **2 sources** :
+L'algorithme collecte **27 critères** répartis en **2 sources** :
 
-- **18 critères enrichis automatiquement** via le module d'enrichissement (APIs externes)
+- **17 critères enrichis automatiquement** via le module d'enrichissement (APIs externes)
 - **10 critères complémentaires** saisis manuellement par l'utilisateur
 
 #### Synthèse des critères et leurs poids
 
 | Source | Nb critères | Poids total |
 |--------|------------|-------------|
-| Enrichissement automatique | 18 | 18.5 |
+| Enrichissement automatique | 17 | 18 |
 | Données complémentaires (saisie) | 10 | 11.5 |
-| **TOTAL** | **28** | **30** |
+| **TOTAL** | **27** | **29.5** |
 
 ### Étape 2 : Matrice de scoring
 
 L'algorithme utilise une **matrice de scoring unique** qui définit comment chaque valeur de critère impacte chaque usage.
 
-Cette matrice contient 28 critères × 7 usages = 196 correspondances de base (davantage avec les valeurs multiples par critère).
+Cette matrice contient 27 critères × 7 usages = 189 correspondances de base (davantage avec les valeurs multiples par critère).
 
 #### Structure de la matrice
 
@@ -221,7 +221,7 @@ Indicateur de confiance basé sur la somme des poids des critères renseignés :
 Fiabilité = (Poids_critères_renseignés / Poids_total) × 10
 ```
 
-Le poids total est de **30** (somme de tous les poids des 28 critères). Chaque critère contribue proportionnellement à son poids.
+Le poids total est de **29.5** (somme de tous les poids des 27 critères). Chaque critère contribue proportionnellement à son poids.
 
 #### Grille d'interprétation
 
@@ -238,9 +238,9 @@ La fiabilité **ne modifie pas** le classement. C'est un indicateur séparé qui
 
 ---
 
-## Liste des 28 critères actifs
+## Liste des 27 critères actifs
 
-### Critères enrichis automatiquement (18)
+### Critères enrichis automatiquement (17)
 
 | # | Critère | Poids | Valeurs | Champ DTO |
 |---|---------|-------|---------|-----------|
@@ -261,7 +261,7 @@ La fiabilité **ne modifie pas** le classement. C'est un indicateur séparé qui
 | 15 | **Zonage patrimonial** | 1 | Non concerné / Site inscrit-classé / Périmètre ABF | `zonagePatrimonial` |
 | 16 | **Zone ZAER (ENR)** | 1 | Non / Oui / Oui avec PV ombrière | `zoneAccelerationEnr` |
 | 17 | **Zonage ABC (logement)** | 0.5 | A / Abis / B1 / B2 / C | `zonageAbcLogement` |
-| 18 | **Distance ITE fret** | 0.5 | < 1 km (bon état) / < 1 km (mauvais état) / > 1 km | `distanceIte` |
+| ~~18~~ | ~~**Distance ITE fret**~~ | ~~0.5~~ | ~~< 1 km (bon état) / < 1 km (mauvais état) / > 1 km~~ | ~~`distanceIte`~~ — **désactivé temporairement, en attente validation Cerema** |
 
 ### Critères complémentaires saisis (10)
 


### PR DESCRIPTION
Isole le critère distanceIte (poids 0.5) de l'algorithme, de l'enrichissement et de l'UI pour permettre le déploiement prod du zonage ABC sans fret. Code fret conservé pour réactivation rapide.
