### PR TITLE
fix(db): répare l'historique de migrations Drizzle

### DIFF
--- a/apps/api/src/shared/database/migrations/0000_initial.sql
+++ b/apps/api/src/shared/database/migrations/0000_initial.sql
@@ -4,6 +4,25 @@
 CREATE EXTENSION IF NOT EXISTS postgis;
 
 
+-- Table evaluations : forme d'origine (avant 0012/0014/0015), altérée par les migrations suivantes.
+-- Recréée ici en IF NOT EXISTS pour les bases vierges. Inerte sur les bases existantes
+-- (migrate est basé sur le timestamp du journal : 0000 ne se rejoue jamais une fois 0020 appliqué).
+CREATE TABLE IF NOT EXISTS "evaluations" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"parcelle_id" varchar(20) NOT NULL,
+	"code_insee" varchar(5) NOT NULL,
+	"date_calcul" timestamp DEFAULT now() NOT NULL,
+	"donnees_enrichissement" jsonb NOT NULL,
+	"donnees_complementaires" jsonb NOT NULL,
+	"resultats" jsonb NOT NULL,
+	"fiabilite" numeric NOT NULL,
+	"version_algorithme" varchar(20) NOT NULL,
+	"source_utilisation" varchar(20) NOT NULL,
+	"integrateur" varchar(255),
+	"utilisateur_id" varchar(50),
+	"commentaire" varchar(1000)
+);
+
 CREATE TABLE IF NOT EXISTS "evenements_utilisateur" (
 	"id" varchar(50) PRIMARY KEY NOT NULL,
 	"type_evenement" varchar(50) NOT NULL,

--- a/apps/api/src/shared/database/migrations/meta/0019_snapshot.json
+++ b/apps/api/src/shared/database/migrations/meta/0019_snapshot.json
@@ -4,6 +4,80 @@
   "version": "7",
   "dialect": "postgresql",
   "tables": {
+    "public.communes": {
+      "name": "communes",
+      "schema": "",
+      "columns": {
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departement": {
+          "name": "departement",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epci_siren": {
+          "name": "epci_siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_communes_epci_siren": {
+          "name": "idx_communes_epci_siren",
+          "columns": [
+            {
+              "expression": "epci_siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communes_epci_siren_epci_siren_fk": {
+          "name": "communes_epci_siren_epci_siren_fk",
+          "tableFrom": "communes",
+          "tableTo": "epci",
+          "columnsFrom": [
+            "epci_siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.enrichissements": {
       "name": "enrichissements",
       "schema": "",
@@ -192,6 +266,62 @@
           "with": {}
         }
       },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.epci": {
+      "name": "epci",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nature_juridique": {
+          "name": "nature_juridique",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departement_siege": {
+          "name": "departement_siege",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nb_communes": {
+          "name": "nb_communes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
@@ -1143,7 +1273,8 @@
         "jauge_depassee",
         "interet_multi_parcelles",
         "interet_mise_en_relation",
-        "interet_export_resultats"
+        "interet_export_resultats",
+        "demande_contact_multisites"
       ]
     }
   },

--- a/apps/api/src/shared/database/migrations/meta/0020_snapshot.json
+++ b/apps/api/src/shared/database/migrations/meta/0020_snapshot.json
@@ -1,9 +1,41 @@
 {
-  "id": "18ef501b-ed3e-44a3-aaad-0ab2dcc80527",
-  "prevId": "51e1382b-a504-4dfb-8ab0-5e40d59c567f",
+  "id": "eb697f69-b87b-450a-87fa-962b74246df9",
+  "prevId": "742c41dd-1e03-4e4a-bb62-21893af94b43",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
+    "public.api_health_snapshots": {
+      "name": "api_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.communes": {
       "name": "communes",
       "schema": "",
@@ -899,9 +931,15 @@
           "primaryKey": false,
           "notNull": true
         },
-        "code_insee": {
-          "name": "code_insee",
-          "type": "varchar(5)",
+        "adresse": {
+          "name": "adresse",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_postal": {
+          "name": "code_postal",
+          "type": "varchar(50)",
           "primaryKey": false,
           "notNull": false
         },
@@ -911,15 +949,9 @@
           "primaryKey": false,
           "notNull": false
         },
-        "departement": {
-          "name": "departement",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "region": {
-          "name": "region",
-          "type": "varchar(100)",
+        "code_siret": {
+          "name": "code_siret",
+          "type": "varchar(50)",
           "primaryKey": false,
           "notNull": false
         },
@@ -949,11 +981,11 @@
         }
       },
       "indexes": {
-        "raw_ite_fret_code_insee_idx": {
-          "name": "raw_ite_fret_code_insee_idx",
+        "raw_ite_fret_code_postal_idx": {
+          "name": "raw_ite_fret_code_postal_idx",
           "columns": [
             {
-              "expression": "code_insee",
+              "expression": "code_postal",
               "isExpression": false,
               "asc": true,
               "nulls": "last"


### PR DESCRIPTION
Corrige la collision de snapshots (0018 prevId, communes/epci, snapshot 0020 manquant) qui bloquait db:generate et ajoute la création idempotente de la table evaluations dans 0000 pour les bases vierges.
