### PR TITLE
feat(evenements): track l'ouverture de la modale multisites

### DIFF
--- a/apps/api/src/shared/database/migrations/0023_ouverture_modale_multisites.sql
+++ b/apps/api/src/shared/database/migrations/0023_ouverture_modale_multisites.sql
@@ -1,0 +1,10 @@
+-- Ajoute la valeur 'ouverture_modale_multisites' à type_evenement_enum si absente
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'ouverture_modale_multisites'
+        AND enumtypid = 'type_evenement_enum'::regtype
+    ) THEN
+        ALTER TYPE "public"."type_evenement_enum" ADD VALUE 'ouverture_modale_multisites';
+    END IF;
+END $$;

--- a/apps/api/src/shared/database/migrations/meta/_journal.json
+++ b/apps/api/src/shared/database/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1779267254575,
       "tag": "0022_besoin_ne_sait_pas",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779267254576,
+      "tag": "0023_ouverture_modale_multisites",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/ui/src/features/resultats/pages/ResultatsPage.tsx
+++ b/apps/ui/src/features/resultats/pages/ResultatsPage.tsx
@@ -79,8 +79,13 @@ export const ResultatsPage: React.FC = () => {
   const { parentOrigin, integrator } = useIframe();
 
   // Hook tracking
-  const { track, trackExporterResultats, trackDemandeContactMultisites, trackEvaluationTerminee } =
-    useEventTracking();
+  const {
+    track,
+    trackExporterResultats,
+    trackOuvertureModaleMultisites,
+    trackDemandeContactMultisites,
+    trackEvaluationTerminee,
+  } = useEventTracking();
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -433,7 +438,10 @@ export const ResultatsPage: React.FC = () => {
                 className="fr-btn fr-btn--secondary"
                 // Fond blanc forcé : le secondary DSFR est transparent et laisse voir le vert
                 style={{ backgroundColor: "#fff" }}
-                onClick={() => setIsContactModalOpen(true)}
+                onClick={() => {
+                  trackOuvertureModaleMultisites(mutabilityData?.evaluationId);
+                  setIsContactModalOpen(true);
+                }}
               >
                 Analyser plusieurs sites
               </button>

--- a/apps/ui/src/shared/hooks/useEventTracking.ts
+++ b/apps/ui/src/shared/hooks/useEventTracking.ts
@@ -98,6 +98,13 @@ export function useEventTracking() {
     [track],
   );
 
+  const trackOuvertureModaleMultisites = useCallback(
+    (evaluationId?: string) => {
+      return track(TypeEvenement.OUVERTURE_MODALE_MULTISITES, { evaluationId });
+    },
+    [track],
+  );
+
   const trackDemandeContactMultisites = useCallback(
     (email: string, besoin: BesoinMultisites, evaluationId?: string) => {
       return track(TypeEvenement.DEMANDE_CONTACT_MULTISITES, {
@@ -151,6 +158,7 @@ export function useEventTracking() {
     trackInteretMultiParcelles,
     trackInteretMiseEnRelation,
     trackExporterResultats,
+    trackOuvertureModaleMultisites,
     trackDemandeContactMultisites,
     trackEvaluationTerminee,
     trackParcelleAjoutee,

--- a/packages/shared-types/src/evenements/enums/evenements.enums.ts
+++ b/packages/shared-types/src/evenements/enums/evenements.enums.ts
@@ -27,6 +27,8 @@ export enum TypeEvenement {
   INTERET_MISE_EN_RELATION = "interet_mise_en_relation",
   INTERET_EXPORT_RESULTATS = "interet_export_resultats",
 
+  // Ouverture de la modale multisites (clic sur le CTA "Analyser plusieurs sites")
+  OUVERTURE_MODALE_MULTISITES = "ouverture_modale_multisites",
   // Demande de mise en relation multisites (modale "Etre contacte")
   DEMANDE_CONTACT_MULTISITES = "demande_contact_multisites",
 }


### PR DESCRIPTION
Nouvel evenement OUVERTURE_MODALE_MULTISITES emis au clic du CTA, pour mesurer le funnel ouverture -> envoi.
