### PR TITLE
chore(deploy): bypass pnpm au runtime Scalingo (pnpm 11)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,4 @@
-postdeploy: echo "Migrations..." && pnpm db:migrate && echo "Postdeploy termine"
+# NB : on bypasse pnpm au runtime — voir README "Bypass de pnpm au runtime (pnpm >= 10.16)".
+# Shims .bin directs, jamais préfixés par `node`. drizzle-kit est en dependencies (non pruné).
+postdeploy: cd apps/api && ./node_modules/.bin/drizzle-kit migrate
 web: node apps/api/dist/src/main

--- a/README.md
+++ b/README.md
@@ -231,6 +231,28 @@ SCALINGO_POSTGRESQL_URL=<fourni par addon PostgreSQL>
 git push scalingo main
 ```
 
+### Bypass de pnpm au runtime (pnpm ≥ 10.16)
+
+> ⚠️ Ne pas réintroduire d'appel `pnpm` dans le `Procfile`.
+
+À partir de pnpm 10.16, chaque invocation `pnpm <x>` lance un `runDepsStatusCheck` au boot
+du conteneur. Le packaging du slug Scalingo casse les hardlinks du store pnpm : pnpm croit
+détecter une divergence de `node_modules`, tente de le purger sans TTY et plante
+(`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`, ou `SIGKILL` au timeout de boot). Réf
+[pnpm#9966](https://github.com/pnpm/pnpm/issues/9966).
+
+Conséquence : **le runtime n'appelle jamais pnpm**.
+
+- `Procfile` → `web: node apps/api/dist/src/main` (Node direct) et
+  `postdeploy: cd apps/api && ./node_modules/.bin/drizzle-kit migrate` (shim `.bin` direct,
+  jamais préfixé par `node` — c'est un script shell). `drizzle-kit` est en **dependencies**
+  d'`apps/api` pour survivre au prune des `devDependencies`.
+- `pnpm-workspace.yaml` → `confirmModulesPurge: false` sécurise les one-shot
+  `scalingo run pnpm …`, et `allowBuilds: { … : false }` évite que pnpm ≥ 11 ne bloque
+  `pnpm install` (build Scalingo) sur `ERR_PNPM_IGNORED_BUILDS`.
+
+Le **build** (`scalingo-postbuild`) utilise toujours pnpm — seul le runtime est concerné.
+
 ## 📊 Tracking Événements
 
 Système de tracking léger pour mesurer l'engagement utilisateur :

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.11.0",
   "private": true,
   "description": "Monorepo pour l'analyse de mutabilité des friches urbaines",
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.5.3",
   "engines": {
     "node": "24.x"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,18 @@ packages:
   - "apps/*"
   - "packages/*"
 minimumReleaseAge: 1440 # 1 jour (en minutes)
+
+# Empêche pnpm de purger interactivement node_modules au runtime (TTY-less).
+# Sans ça, `pnpm start` sur Scalingo plante avec ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY
+# si pnpm détecte une discrepancy entre node_modules installé et la config courante.
+confirmModulesPurge: false
+
+# pnpm >=11 refuse de continuer tant que chaque dépendance avec un script de build n'est pas
+# catégorisée (ERR_PNPM_IGNORED_BUILDS, exit 1) — ce qui casserait `pnpm install` au build
+# Scalingo. allowBuilds = allow-list par-dessus `ignore-scripts=true` (.npmrc) : true pour les
+# vrais builds natifs, false pour la pure télémétrie. Remplace `onlyBuiltDependencies` (pnpm 9-10).
+allowBuilds:
+  esbuild: true # bundler (vite/vitest/drizzle-kit) — binaire natif par plateforme
+  "@swc/core": true # compilateur natif (unplugin-swc, tests)
+  "@nestjs/core": false # postinstall = message de funding, inutile
+  "@scarf/scarf": false # télémétrie, à ne pas exécuter


### PR DESCRIPTION
Procfile appelle node et le shim drizzle-kit directement ; garde-fous pnpm-workspace (confirmModulesPurge, allowBuilds) pour éviter la purge de node_modules au boot et le blocage des builds ignorés.
