### PR TITLE
feat(analytics): identifiant visiteur anonyme persistant pour la récurrence + pages juridiques + storageConfig

### DIFF
--- a/apps/api/src/evaluation/dto/input/calculer-mutabilite.dto.ts
+++ b/apps/api/src/evaluation/dto/input/calculer-mutabilite.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import {
   CalculerMutabiliteInputDto as ICalculerMutabiliteInput,
   EnrichissementOutputDto,
@@ -23,4 +23,10 @@ export class CalculerMutabiliteSwaggerDto implements ICalculerMutabiliteInput {
     type: DonneesComplementairesSwaggerDto,
   })
   donneesComplementaires: DonneesComplementairesInputDto;
+
+  @ApiPropertyOptional({
+    description:
+      "Identifiant visiteur anonyme persistant (localStorage). Permet de mesurer la récurrence cross-visite.",
+  })
+  visitorId?: string;
 }

--- a/apps/api/src/evaluation/entities/evaluation.entity.ts
+++ b/apps/api/src/evaluation/entities/evaluation.entity.ts
@@ -28,6 +28,9 @@ export class Evaluation {
   origine: OrigineUtilisation;
   versionAlgorithme: string;
 
+  // Identifiant visiteur anonyme persistant (stocké en base dans utilisateur_id)
+  visitorId?: string;
+
   constructor(
     siteId: string,
     codeInsee: string,
@@ -36,6 +39,7 @@ export class Evaluation {
     resultats: MutabiliteOutputDto,
     origine: OrigineUtilisation,
     nombreParcelles?: number,
+    visitorId?: string,
   ) {
     this.siteId = siteId;
     this.nombreParcelles = nombreParcelles;
@@ -46,6 +50,7 @@ export class Evaluation {
     this.resultats = resultats;
     this.origine = origine;
     this.versionAlgorithme = VERSION_ALGO;
+    this.visitorId = visitorId;
   }
 
   /**

--- a/apps/api/src/evaluation/repositories/evaluation.repository.ts
+++ b/apps/api/src/evaluation/repositories/evaluation.repository.ts
@@ -51,6 +51,8 @@ export class EvaluationRepository {
       sourceUtilisation: evaluation.origine.source,
       integrateur: evaluation.origine.integrateur,
       versionAlgorithme: evaluation.versionAlgorithme,
+      // Identifiant visiteur anonyme persistant (mesure de récurrence cross-visite)
+      utilisateurId: evaluation.visitorId ?? null,
       evaluationSourceId,
     });
 

--- a/apps/api/src/evaluation/services/orchestrateur.service.spec.ts
+++ b/apps/api/src/evaluation/services/orchestrateur.service.spec.ts
@@ -337,6 +337,61 @@ describe("OrchestrateurService", () => {
       expect(result.evaluationId).toBe("eval-new");
     });
 
+    it("devrait propager le visitorId à l'évaluation sauvegardée (calcul complet)", async () => {
+      evaluationRepository.findValidCache.mockResolvedValue(null);
+
+      const mockSite = new Site();
+      mockSite.identifiantParcelle = "490055000AI0001";
+      vi.spyOn(Site, "fromEnrichissement").mockReturnValue(mockSite);
+      vi.spyOn(mockSite, "estComplete").mockReturnValue(true);
+
+      calculService.calculer.mockResolvedValue({
+        fiabilite: { note: 7.5, text: "Bonne" },
+        resultats: [],
+      } as any);
+      evaluationRepository.save.mockResolvedValue("eval-new");
+
+      const input = {
+        donneesEnrichies: mockEnrichissement,
+        donneesComplementaires: mockDonneesComplementaires,
+        visitorId: "550e8400-e29b-41d4-a716-446655440000",
+      };
+
+      await service.calculerMutabilite(input);
+
+      const saveCall = evaluationRepository.save.mock.calls[0] as [
+        { visitorId?: string },
+        ...any[],
+      ];
+      expect(saveCall[0].visitorId).toBe("550e8400-e29b-41d4-a716-446655440000");
+    });
+
+    it("devrait propager le visitorId à l'évaluation sauvegardée (cache hit)", async () => {
+      const cachedEvaluation = {
+        id: "cached-eval-123",
+        resultats: { fiabilite: { note: 8 }, resultats: [] },
+        donneesEnrichissement: mockEnrichissement,
+        donneesComplementaires: mockDonneesComplementaires,
+      };
+
+      evaluationRepository.findValidCache.mockResolvedValue(cachedEvaluation);
+      evaluationRepository.save.mockResolvedValue("new-eval-456");
+
+      const input = {
+        donneesEnrichies: mockEnrichissement,
+        donneesComplementaires: mockDonneesComplementaires,
+        visitorId: "550e8400-e29b-41d4-a716-446655440000",
+      };
+
+      await service.calculerMutabilite(input);
+
+      const saveCall = evaluationRepository.save.mock.calls[0] as [
+        { visitorId?: string },
+        ...any[],
+      ];
+      expect(saveCall[0].visitorId).toBe("550e8400-e29b-41d4-a716-446655440000");
+    });
+
     it("devrait effectuer le calcul si donnees complementaires contiennent 'je ne sais pas'", async () => {
       // findValidCache retourne null car il detecte "je ne sais pas"
       evaluationRepository.findValidCache.mockResolvedValue(null);

--- a/apps/api/src/evaluation/services/orchestrateur.service.ts
+++ b/apps/api/src/evaluation/services/orchestrateur.service.ts
@@ -80,6 +80,7 @@ export class OrchestrateurService {
         cached.resultats,
         origine,
         nombreParcelles,
+        input.visitorId,
       );
 
       const evaluationId = await this.evaluationRepository.save(evaluation, cached.id);
@@ -124,6 +125,7 @@ export class OrchestrateurService {
       resultats,
       origine,
       nombreParcelles,
+      input.visitorId,
     );
 
     // Sauvegarde l'évaluation et retourne l'id

--- a/apps/api/src/evenements/dto/input/evenement.dto.ts
+++ b/apps/api/src/evenements/dto/input/evenement.dto.ts
@@ -37,6 +37,14 @@ export class EvenementInputDto implements IEvenementInput {
 
   @IsOptional()
   @IsString()
+  @MaxLength(50)
+  @Matches(/^[a-z0-9-]+$/i, {
+    message: "visitorId contient des caractères non autorisés",
+  })
+  visitorId?: string;
+
+  @IsOptional()
+  @IsString()
   @MaxLength(100)
   ref?: string;
 

--- a/apps/api/src/evenements/entities/evenement.entity.ts
+++ b/apps/api/src/evenements/entities/evenement.entity.ts
@@ -14,6 +14,7 @@ export class EvenementUtilisateur {
   integrateur?: string;
   userAgent?: string;
   sessionId?: string;
+  visitorId?: string;
 
   constructor(data: {
     id: string;
@@ -28,6 +29,7 @@ export class EvenementUtilisateur {
     integrateur?: string;
     userAgent?: string;
     sessionId?: string;
+    visitorId?: string;
   }) {
     Object.assign(this, data);
   }

--- a/apps/api/src/evenements/repositories/evenement.repository.ts
+++ b/apps/api/src/evenements/repositories/evenement.repository.ts
@@ -21,6 +21,7 @@ export class EvenementRepository {
       integrateur: evenement.integrateur || null,
       userAgent: evenement.userAgent || null,
       sessionId: evenement.sessionId || null,
+      visitorId: evenement.visitorId || null,
     });
   }
 }

--- a/apps/api/src/evenements/services/evenement.service.spec.ts
+++ b/apps/api/src/evenements/services/evenement.service.spec.ts
@@ -477,6 +477,44 @@ describe("EvenementService - Sécurité", () => {
     });
   });
 
+  describe("Identifiant visiteur (visitorId)", () => {
+    it("devrait propager le visitorId à l'événement enregistré", async () => {
+      const input = {
+        typeEvenement: TypeEvenement.RESULTATS_MUTABILITE,
+        visitorId: "550e8400-e29b-41d4-a716-446655440000",
+      };
+
+      await service.enregistrerEvenement(input);
+
+      const savedEvent = vi.mocked(mockRepository.enregistrerEvenement).mock.calls[0][0];
+      expect(savedEvent.visitorId).toBe("550e8400-e29b-41d4-a716-446655440000");
+    });
+
+    it("devrait gérer l'absence de visitorId sans erreur", async () => {
+      const input = {
+        typeEvenement: TypeEvenement.RESULTATS_MUTABILITE,
+      };
+
+      await service.enregistrerEvenement(input);
+
+      const savedEvent = vi.mocked(mockRepository.enregistrerEvenement).mock.calls[0][0];
+      expect(savedEvent.visitorId).toBeUndefined();
+    });
+
+    it("devrait sanitiser le visitorId (caractères dangereux supprimés)", async () => {
+      const input = {
+        typeEvenement: TypeEvenement.RESULTATS_MUTABILITE,
+        visitorId: "abc<script>123",
+      };
+
+      await service.enregistrerEvenement(input);
+
+      const savedEvent = vi.mocked(mockRepository.enregistrerEvenement).mock.calls[0][0];
+      expect(savedEvent.visitorId).not.toContain("<");
+      expect(savedEvent.visitorId).not.toContain(">");
+    });
+  });
+
   describe("Demande de contact multisites", () => {
     it("devrait router vers ContactService et ne pas persister l'email dans l'événement", async () => {
       const input = {

--- a/apps/api/src/evenements/services/evenement.service.ts
+++ b/apps/api/src/evenements/services/evenement.service.ts
@@ -57,6 +57,7 @@ export class EvenementService {
       integrateur: this.sanitizeString(metadata?.integrateur),
       userAgent: this.sanitizeUserAgent(metadata?.userAgent),
       sessionId: this.sanitizeString(input.sessionId),
+      visitorId: this.sanitizeString(input.visitorId),
     });
 
     await this.evenementRepository.enregistrerEvenement(evenement);

--- a/apps/api/src/shared/database/migrations/0024_strong_wolfpack.sql
+++ b/apps/api/src/shared/database/migrations/0024_strong_wolfpack.sql
@@ -1,0 +1,4 @@
+-- Identifiant visiteur anonyme persistant (mesure de récurrence cross-visite)
+-- IF NOT EXISTS par sécurité : le snapshot Drizzle était désynchronisé (migrations 0021-0023 écrites à la main)
+ALTER TABLE "evenements_utilisateur" ADD COLUMN IF NOT EXISTS "visitor_id" varchar(50);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_visitor_id" ON "evenements_utilisateur" USING btree ("visitor_id");

--- a/apps/api/src/shared/database/migrations/meta/0024_snapshot.json
+++ b/apps/api/src/shared/database/migrations/meta/0024_snapshot.json
@@ -1,0 +1,1449 @@
+{
+  "id": "389fd2bf-3b47-4ce8-aa4d-707e2b3bba6f",
+  "prevId": "eb697f69-b87b-450a-87fa-962b74246df9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_health_snapshots": {
+      "name": "api_health_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communes": {
+      "name": "communes",
+      "schema": "",
+      "columns": {
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "departement": {
+          "name": "departement",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epci_siren": {
+          "name": "epci_siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_communes_epci_siren": {
+          "name": "idx_communes_epci_siren",
+          "columns": [
+            {
+              "expression": "epci_siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communes_epci_siren_epci_siren_fk": {
+          "name": "communes_epci_siren_epci_siren_fk",
+          "tableFrom": "communes",
+          "tableTo": "epci",
+          "columnsFrom": [
+            "epci_siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demandes_contact": {
+      "name": "demandes_contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "besoin": {
+          "name": "besoin",
+          "type": "besoin_multisites_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrateur": {
+          "name": "integrateur",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_confirmation_envoye": {
+          "name": "mail_confirmation_envoye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "date_creation": {
+          "name": "date_creation",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_demandes_contact_date": {
+          "name": "idx_demandes_contact_date",
+          "columns": [
+            {
+              "expression": "date_creation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_demandes_contact_besoin": {
+          "name": "idx_demandes_contact_besoin",
+          "columns": [
+            {
+              "expression": "besoin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichissements": {
+      "name": "enrichissements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifiant_cadastral": {
+          "name": "identifiant_cadastral",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statut": {
+          "name": "statut",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donnees": {
+          "name": "donnees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_erreur": {
+          "name": "message_erreur",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_erreur": {
+          "name": "code_erreur",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources_reussies": {
+          "name": "sources_reussies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources_echouees": {
+          "name": "sources_echouees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_enrichissement": {
+          "name": "date_enrichissement",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duree_ms": {
+          "name": "duree_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_utilisation": {
+          "name": "source_utilisation",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrateur": {
+          "name": "integrateur",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_api": {
+          "name": "version_api",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "centroid_latitude": {
+          "name": "centroid_latitude",
+          "type": "numeric(10, 7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "centroid_longitude": {
+          "name": "centroid_longitude",
+          "type": "numeric(10, 7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometrie": {
+          "name": "geometrie",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichissement_source_id": {
+          "name": "enrichissement_source_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_enrichissements_identifiant": {
+          "name": "idx_enrichissements_identifiant",
+          "columns": [
+            {
+              "expression": "identifiant_cadastral",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_enrichissements_statut": {
+          "name": "idx_enrichissements_statut",
+          "columns": [
+            {
+              "expression": "statut",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_enrichissements_date": {
+          "name": "idx_enrichissements_date",
+          "columns": [
+            {
+              "expression": "date_enrichissement",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_enrichissements_centroid": {
+          "name": "idx_enrichissements_centroid",
+          "columns": [
+            {
+              "expression": "centroid_latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "centroid_longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.epci": {
+      "name": "epci",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nature_juridique": {
+          "name": "nature_juridique",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departement_siege": {
+          "name": "departement_siege",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nb_communes": {
+          "name": "nb_communes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluations": {
+      "name": "evaluations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre_parcelles": {
+          "name": "nombre_parcelles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_calcul": {
+          "name": "date_calcul",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "donnees_enrichissement": {
+          "name": "donnees_enrichissement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donnees_complementaires": {
+          "name": "donnees_complementaires",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resultats": {
+          "name": "resultats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fiabilite": {
+          "name": "fiabilite",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_algorithme": {
+          "name": "version_algorithme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_utilisation": {
+          "name": "source_utilisation",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrateur": {
+          "name": "integrateur",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilisateur_id": {
+          "name": "utilisateur_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commentaire": {
+          "name": "commentaire",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_source_id": {
+          "name": "evaluation_source_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evenements_utilisateur": {
+      "name": "evenements_utilisateur",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type_evenement": {
+          "name": "type_evenement",
+          "type": "type_evenement_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifiant_cadastral": {
+          "name": "identifiant_cadastral",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "donnees": {
+          "name": "donnees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_creation": {
+          "name": "date_creation",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_campagne": {
+          "name": "source_campagne",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode_utilisation": {
+          "name": "mode_utilisation",
+          "type": "mode_utilisation_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrateur": {
+          "name": "integrateur",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_type_evenement": {
+          "name": "idx_type_evenement",
+          "columns": [
+            {
+              "expression": "type_evenement",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_evaluation_id": {
+          "name": "idx_evaluation_id",
+          "columns": [
+            {
+              "expression": "evaluation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_date_creation": {
+          "name": "idx_date_creation",
+          "columns": [
+            {
+              "expression": "date_creation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_id": {
+          "name": "idx_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_visitor_id": {
+          "name": "idx_visitor_id",
+          "columns": [
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_ademe_sites_pollues": {
+      "name": "raw_ademe_sites_pollues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nom_site": {
+          "name": "nom_site",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commune": {
+          "name": "commune",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parcelles_cadastrales": {
+          "name": "parcelles_cadastrales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_site_m2": {
+          "name": "surface_site_m2",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "typologie_intervention": {
+          "name": "typologie_intervention",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etat_operation": {
+          "name": "etat_operation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departement": {
+          "name": "departement",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raw_ademe_sites_pollues_code_insee_idx": {
+          "name": "raw_ademe_sites_pollues_code_insee_idx",
+          "columns": [
+            {
+              "expression": "code_insee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_ademe_sites_pollues_spatial_idx": {
+          "name": "raw_ademe_sites_pollues_spatial_idx",
+          "columns": [
+            {
+              "expression": "ST_SetSRID(ST_MakePoint(\"longitude\", \"latitude\"), 4326)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_bpe": {
+      "name": "raw_bpe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_equipement": {
+          "name": "code_equipement",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_commune": {
+          "name": "code_commune",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(15, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(15, 12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualite_xy": {
+          "name": "qualite_xy",
+          "type": "varchar(1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annee_source": {
+          "name": "annee_source",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_raw_bpe_code_equipement": {
+          "name": "idx_raw_bpe_code_equipement",
+          "columns": [
+            {
+              "expression": "code_equipement",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_raw_bpe_code_commune": {
+          "name": "idx_raw_bpe_code_commune",
+          "columns": [
+            {
+              "expression": "code_commune",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_imports_log": {
+      "name": "raw_imports_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataset_name": {
+          "name": "dataset_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "import_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "rows_imported": {
+          "name": "rows_imported",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rows_filtered": {
+          "name": "rows_filtered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rows_total": {
+          "name": "rows_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_version": {
+          "name": "import_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_ite_fret": {
+      "name": "raw_ite_fret",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_postal": {
+          "name": "code_postal",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_siret": {
+          "name": "code_siret",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gestionnaire": {
+          "name": "gestionnaire",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etat": {
+          "name": "etat",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "raw_ite_fret_code_postal_idx": {
+          "name": "raw_ite_fret_code_postal_idx",
+          "columns": [
+            {
+              "expression": "code_postal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_ite_fret_spatial_idx": {
+          "name": "raw_ite_fret_spatial_idx",
+          "columns": [
+            {
+              "expression": "ST_SetSRID(ST_MakePoint(\"longitude\", \"latitude\"), 4326)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_transport_stops": {
+      "name": "raw_transport_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stop_name": {
+          "name": "stop_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_lat": {
+          "name": "stop_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_lon": {
+          "name": "stop_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raw_transport_stops_spatial_idx": {
+          "name": "raw_transport_stops_spatial_idx",
+          "columns": [
+            {
+              "expression": "ST_SetSRID(ST_MakePoint(\"stop_lon\", \"stop_lat\"), 4326)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "raw_transport_stops_location_type_idx": {
+          "name": "raw_transport_stops_location_type_idx",
+          "columns": [
+            {
+              "expression": "location_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifiants_cadastraux": {
+          "name": "identifiants_cadastraux",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre_parcelles": {
+          "name": "nombre_parcelles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_insee": {
+          "name": "code_insee",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parcelle_predominante": {
+          "name": "parcelle_predominante",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statut": {
+          "name": "statut",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donnees": {
+          "name": "donnees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_erreur": {
+          "name": "message_erreur",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_erreur": {
+          "name": "code_erreur",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources_reussies": {
+          "name": "sources_reussies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sources_echouees": {
+          "name": "sources_echouees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_enrichissement": {
+          "name": "date_enrichissement",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duree_ms": {
+          "name": "duree_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_utilisation": {
+          "name": "source_utilisation",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrateur": {
+          "name": "integrateur",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_api": {
+          "name": "version_api",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "centroid_latitude": {
+          "name": "centroid_latitude",
+          "type": "numeric(10, 7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "centroid_longitude": {
+          "name": "centroid_longitude",
+          "type": "numeric(10, 7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometrie": {
+          "name": "geometrie",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_source_id": {
+          "name": "site_source_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sites_statut": {
+          "name": "idx_sites_statut",
+          "columns": [
+            {
+              "expression": "statut",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sites_date": {
+          "name": "idx_sites_date",
+          "columns": [
+            {
+              "expression": "date_enrichissement",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sites_centroid": {
+          "name": "idx_sites_centroid",
+          "columns": [
+            {
+              "expression": "centroid_latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "centroid_longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.besoin_multisites_enum": {
+      "name": "besoin_multisites_enum",
+      "schema": "public",
+      "values": [
+        "suivi_comparaison",
+        "integration_outils",
+        "ne-sait-pas"
+      ]
+    },
+    "public.type_evenement_enum": {
+      "name": "type_evenement_enum",
+      "schema": "public",
+      "values": [
+        "visite",
+        "enrichissement_termine",
+        "qualification_site",
+        "qualification_environnement",
+        "qualification_risques",
+        "resultats_mutabilite",
+        "donnees_complementaires_saisies",
+        "evaluation_terminee",
+        "feedback_pertinence_classement",
+        "parcelle_ajoutee",
+        "parcelle_supprimee",
+        "jauge_depassee",
+        "interet_multi_parcelles",
+        "interet_mise_en_relation",
+        "interet_export_resultats",
+        "ouverture_modale_multisites",
+        "demande_contact_multisites"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/shared/database/migrations/meta/_journal.json
+++ b/apps/api/src/shared/database/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1779267254576,
       "tag": "0023_ouverture_modale_multisites",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1781692006782,
+      "tag": "0024_strong_wolfpack",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/shared/database/schemas/evenements.schema.ts
+++ b/apps/api/src/shared/database/schemas/evenements.schema.ts
@@ -26,11 +26,14 @@ export const evenements_utilisateur = pgTable(
     integrateur: varchar("integrateur", { length: 255 }),
     userAgent: varchar("user_agent", { length: 500 }),
     sessionId: varchar("session_id", { length: 100 }),
+    // Identifiant visiteur anonyme persistant (localStorage), stable entre visites
+    visitorId: varchar("visitor_id", { length: 50 }),
   },
   (table) => [
     index("idx_type_evenement").on(table.typeEvenement),
     index("idx_evaluation_id").on(table.evaluationId),
     index("idx_date_creation").on(table.dateCreation),
     index("idx_session_id").on(table.sessionId),
+    index("idx_visitor_id").on(table.visitorId),
   ],
 );

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -25,6 +25,9 @@ import { StatistiquesPage } from "./features/statistiques/pages/StatistiquesPage
 import { CCI92Page } from "./features/cci92/pages/CCI92Page";
 import { PartenairesPage } from "./features/cci92/pages/PartenairesPage";
 import { DonneesExternesPage } from "./features/donnees-externes/pages/DonneesExternesPage";
+import { MentionsLegalesPage } from "./features/legal/pages/MentionsLegalesPage";
+import { PolitiqueConfidentialitePage } from "./features/legal/pages/PolitiqueConfidentialitePage";
+import { AccessibilitePage } from "./features/legal/pages/AccessibilitePage";
 
 function AppContent() {
   const { track } = useEventTracking();
@@ -66,6 +69,11 @@ function AppContent() {
 
         {/* Statut technique */}
         <Route path={ROUTES.DONNEES_EXTERNES} element={<DonneesExternesPage />} />
+
+        {/* Pages légales */}
+        <Route path={ROUTES.MENTIONS_LEGALES} element={<MentionsLegalesPage />} />
+        <Route path={ROUTES.POLITIQUE_CONFIDENTIALITE} element={<PolitiqueConfidentialitePage />} />
+        <Route path={ROUTES.ACCESSIBILITE} element={<AccessibilitePage />} />
 
         {/* Partenaires */}
         <Route path={ROUTES.PARTENAIRES} element={<PartenairesPage />} />

--- a/apps/ui/src/features/cci92/hooks/useCustomSites.ts
+++ b/apps/ui/src/features/cci92/hooks/useCustomSites.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { isValidParcelId, normalizeParcelId } from "@mutafriches/shared-types";
 import type { CCI92Site } from "../data/parcelles-cci92";
+import { STORAGE_KEYS } from "@shared/config/storage-keys.config";
 
-const STORAGE_KEY = "cci92-custom-sites";
+const STORAGE_KEY = STORAGE_KEYS.CCI92_CUSTOM_SITES;
 const STORAGE_VERSION = 1;
 
 export const CUSTOM_COMMUNE_LABEL = "Ajouts personnalisés";

--- a/apps/ui/src/features/legal/pages/AccessibilitePage.tsx
+++ b/apps/ui/src/features/legal/pages/AccessibilitePage.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Layout } from "@shared/components/layout/Layout";
+
+export const AccessibilitePage: React.FC = () => {
+  return (
+    <Layout>
+      <div className="fr-mb-4w">
+        <h1 className="fr-h3">Déclaration d'accessibilité</h1>
+        <p className="fr-text--sm fr-mb-0">Établie le 24 juin 2026.</p>
+      </div>
+
+      <p>
+        L'ADEME s'engage à rendre ses sites internet accessibles conformément à l'article 47 de la
+        loi n° 2005-102 du 11 février 2005. Cette déclaration d'accessibilité s'applique au site
+        Mutafriches.
+      </p>
+
+      <h2 className="fr-h5">État de conformité</h2>
+      <p>
+        En l'absence d'audit et dans l'attente de celui-ci, le site Mutafriches n'est{" "}
+        <strong>pas en conformité</strong> avec le référentiel général d'amélioration de
+        l'accessibilité (RGAA). Les non-conformités éventuelles n'ont pas encore été recensées.
+      </p>
+
+      <h2 className="fr-h5">Contenus non accessibles</h2>
+      <p>
+        Le site s'appuie sur le Système de design de l'État (DSFR), conçu pour respecter les
+        critères d'accessibilité, mais aucun audit complet n'a encore été réalisé. Les contenus non
+        conformes seront listés ici à l'issue de cet audit.
+      </p>
+
+      <h2 className="fr-h5">Établissement de cette déclaration</h2>
+      <p>
+        Cette déclaration a été établie le 24 juin 2026. Technologie utilisée pour la réalisation du
+        site : React, avec le Système de design de l'État (DSFR). Aucun test utilisateur ni outil
+        d'évaluation automatisé n'a encore été employé pour vérifier l'accessibilité.
+      </p>
+
+      <h2 className="fr-h5">Retour d'information et contact</h2>
+      <p>
+        Si vous n'arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter l'équipe
+        Mutafriches pour être orienté vers une alternative accessible ou obtenir le contenu sous une
+        autre forme.
+      </p>
+
+      <h2 className="fr-h5">Voie de recours</h2>
+      <p>
+        Si vous avez signalé un défaut d'accessibilité vous empêchant d'accéder à un contenu ou à un
+        service et que vous n'avez pas obtenu de réponse satisfaisante, vous pouvez :
+      </p>
+      <ul>
+        <li>
+          écrire un message au{" "}
+          <a
+            href="https://formulaire.defenseurdesdroits.fr/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Défenseur des droits
+          </a>{" "}
+          ;
+        </li>
+        <li>contacter le délégué du Défenseur des droits dans votre région ;</li>
+        <li>
+          envoyer un courrier par la poste (gratuit, sans timbre) : Défenseur des droits, Libre
+          réponse 71120, 75342 Paris CEDEX 07.
+        </li>
+      </ul>
+    </Layout>
+  );
+};

--- a/apps/ui/src/features/legal/pages/MentionsLegalesPage.tsx
+++ b/apps/ui/src/features/legal/pages/MentionsLegalesPage.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Layout } from "@shared/components/layout/Layout";
+
+export const MentionsLegalesPage: React.FC = () => {
+  return (
+    <Layout>
+      <div className="fr-mb-4w">
+        <h1 className="fr-h3">Mentions légales</h1>
+        <p className="fr-text--sm fr-mb-0">Dernière mise à jour : 24 juin 2026.</p>
+      </div>
+
+      <h2 className="fr-h5">Éditeur</h2>
+      <p>
+        Mutafriches est édité par l'Agence de la transition écologique (ADEME), établissement public
+        à caractère industriel et commercial, dont le siège est situé 20 avenue du Grésillé, BP
+        90406, 49004 Angers Cedex 01.
+      </p>
+      <p>
+        Le service est développé dans le cadre du programme beta.gouv de la Direction
+        interministérielle du numérique (DINUM).
+      </p>
+
+      <h2 className="fr-h5">Directeur de la publication</h2>
+      <p>Le directeur de la publication est le Président-directeur général de l'ADEME.</p>
+
+      <h2 className="fr-h5">Hébergement</h2>
+      <p>
+        Le site est hébergé par Scalingo SAS, 3 place de Haguenau, 67000 Strasbourg, France. Les
+        données sont hébergées au sein de l'Union européenne.
+      </p>
+
+      <h2 className="fr-h5">Contact</h2>
+      <p>
+        Pour toute question relative au service, vous pouvez écrire à l'équipe Mutafriches via les
+        coordonnées indiquées sur le site de l'ADEME.
+      </p>
+
+      <h2 className="fr-h5">Propriété intellectuelle</h2>
+      <p>
+        Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce
+        site sont proposés sous{" "}
+        <a
+          href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          licence Etalab 2.0
+        </a>
+        .
+      </p>
+
+      <h2 className="fr-h5">Données personnelles</h2>
+      <p>
+        Les modalités de traitement des données à caractère personnel sont décrites dans la{" "}
+        <a href="/politique-de-confidentialite">politique de confidentialité</a>.
+      </p>
+    </Layout>
+  );
+};

--- a/apps/ui/src/features/legal/pages/PolitiqueConfidentialitePage.tsx
+++ b/apps/ui/src/features/legal/pages/PolitiqueConfidentialitePage.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { Layout } from "@shared/components/layout/Layout";
+
+export const PolitiqueConfidentialitePage: React.FC = () => {
+  return (
+    <Layout>
+      <div className="fr-mb-4w">
+        <h1 className="fr-h3">Politique de confidentialité</h1>
+        <p className="fr-text--sm fr-mb-0">Dernière mise à jour : 24 juin 2026.</p>
+      </div>
+
+      <p className="fr-text--lg">
+        Mutafriches est un service public, édité par l'ADEME, qui aide les collectivités et acteurs
+        de l'aménagement à analyser la mutabilité des friches urbaines. Cette politique décrit, de
+        façon simple, quelles données sont traitées et pourquoi.
+      </p>
+
+      <h2 className="fr-h5">1. Responsable de traitement</h2>
+      <p>
+        Le responsable de traitement est l'Agence de la transition écologique (ADEME), établissement
+        public dont le siège est situé 20 avenue du Grésillé, BP 90406, 49004 Angers Cedex 01.
+        L'ADEME a désigné un délégué à la protection des données (DPO), point de contact privilégié
+        de la Commission nationale de l'informatique et des libertés (CNIL).
+      </p>
+
+      <h2 className="fr-h5">2. Quelles données sont collectées ?</h2>
+      <p>Mutafriches fonctionne sans création de compte ni authentification. Sont traités :</p>
+      <ul>
+        <li>
+          les <strong>identifiants cadastraux</strong> et données de localisation des parcelles que
+          vous analysez (données publiques, non personnelles dans la majorité des cas) ;
+        </li>
+        <li>
+          un <strong>identifiant visiteur anonyme</strong> stocké dans votre navigateur, qui ne
+          contient aucune donnée personnelle et sert uniquement à mesurer la récurrence d'usage ;
+        </li>
+        <li>
+          des <strong>données techniques</strong> liées à la navigation (type de navigateur,
+          journaux de connexion) ;
+        </li>
+        <li>
+          votre <strong>adresse e-mail</strong>, uniquement si vous nous l'indiquez via une demande
+          de contact ; elle sert à vous répondre et n'est pas conservée dans nos statistiques.
+        </li>
+      </ul>
+
+      <h2 className="fr-h5">3. Pourquoi ces données sont-elles traitées ?</h2>
+      <ul>
+        <li>fournir l'analyse de mutabilité des friches demandée ;</li>
+        <li>
+          mesurer l'usage du service et l'améliorer (statistiques anonymes, dont la part
+          d'utilisateurs récurrents et leur provenance) ;
+        </li>
+        <li>répondre aux demandes de contact que vous nous adressez.</li>
+      </ul>
+
+      <h2 className="fr-h5">4. Sur quelle base légale ?</h2>
+      <p>
+        Les traitements reposent sur l'exécution d'une <strong>mission d'intérêt public</strong>
+        dont est investie l'ADEME. La mesure d'audience est réalisée à des fins strictement internes
+        d'amélioration du service.
+      </p>
+
+      <h2 className="fr-h5">5. Combien de temps sont-elles conservées ?</h2>
+      <p>
+        Les données d'usage (analyses, événements et identifiant visiteur anonyme) sont conservées
+        pendant une durée maximale de <strong>36 mois</strong>. Les adresses e-mail des demandes de
+        contact sont conservées le temps nécessaire au traitement de la demande, puis archivées
+        conformément aux délais légaux applicables.
+      </p>
+      <p className="fr-text--sm fr-mb-0">
+        Cette durée est provisoire et fera l'objet d'une politique de purge dédiée.
+      </p>
+
+      <h2 className="fr-h5">6. Qui a accès aux données ?</h2>
+      <p>
+        Seules les personnes habilitées de l'équipe Mutafriches et de l'ADEME accèdent aux données,
+        pour les finalités décrites ci-dessus. L'hébergement est assuré par Scalingo (France, Union
+        européenne). Aucune donnée n'est cédée à des tiers à des fins commerciales ni transférée
+        hors de l'Union européenne.
+      </p>
+
+      <h2 className="fr-h5">7. Cookies et traceurs</h2>
+      <p>
+        Mutafriches n'utilise <strong>aucun cookie publicitaire ni traceur tiers</strong>. Seul un
+        identifiant anonyme est stocké localement dans votre navigateur (clé
+        <code> mutafriches_visitor_id</code>) à des fins de mesure d'audience interne. Vous pouvez
+        le supprimer à tout moment en vidant les données de site de votre navigateur.
+      </p>
+
+      <h2 className="fr-h5">8. Vos droits</h2>
+      <p>
+        Conformément au RGPD et à la loi « Informatique et libertés », vous disposez d'un droit
+        d'accès, de rectification, d'effacement, de limitation et d'opposition sur vos données. Pour
+        les exercer, contactez le délégué à la protection des données de l'ADEME. Si vous estimez,
+        après nous avoir contactés, que vos droits ne sont pas respectés, vous pouvez adresser une
+        réclamation à la{" "}
+        <a href="https://www.cnil.fr/" rel="noopener noreferrer" target="_blank">
+          CNIL
+        </a>
+        .
+      </p>
+    </Layout>
+  );
+};

--- a/apps/ui/src/features/legal/pages/PolitiqueConfidentialitePage.tsx
+++ b/apps/ui/src/features/legal/pages/PolitiqueConfidentialitePage.tsx
@@ -68,7 +68,7 @@ export const PolitiqueConfidentialitePage: React.FC = () => {
         contact sont conservées le temps nécessaire au traitement de la demande, puis archivées
         conformément aux délais légaux applicables.
       </p>
-      <p className="fr-text--sm fr-mb-0">
+      <p className="fr-text--sm fr-mb-2w">
         Cette durée est provisoire et fera l'objet d'une politique de purge dédiée.
       </p>
 

--- a/apps/ui/src/features/resultats/pages/ResultatsPage.tsx
+++ b/apps/ui/src/features/resultats/pages/ResultatsPage.tsx
@@ -168,6 +168,12 @@ export const ResultatsPage: React.FC = () => {
       setMutabilityData(result);
       sendIframeMessages(result);
 
+      // Tracker l'affichage des résultats avec l'evaluationId (dédoublonnage analytics)
+      track(TypeEvenement.RESULTATS_MUTABILITE, {
+        evaluationId: result.evaluationId || undefined,
+        identifiantCadastral: state.identifiantSite || undefined,
+      });
+
       // Tracker l'événement d'évaluation terminée (seulement si evaluationId valide)
       if (result.evaluationId) {
         await trackEvaluationTerminee(result.evaluationId, state.identifiantSite || undefined);
@@ -192,6 +198,7 @@ export const ResultatsPage: React.FC = () => {
     iframeCommunicator,
     integrator,
     state.identifiantSite,
+    track,
     trackEvaluationTerminee,
   ]);
 
@@ -208,17 +215,18 @@ export const ResultatsPage: React.FC = () => {
     hasInitializedRef.current = true;
     setCurrentStep(4); // Étape 4 = résultats
 
-    // Tracker l'arrivée sur la page
-    track(TypeEvenement.RESULTATS_MUTABILITE, {
-      identifiantCadastral: state.identifiantSite || undefined,
-    });
-
     if (state.mutabilityResult) {
+      // Résultat déjà disponible : tracker l'affichage des résultats avec l'evaluationId connu
+      track(TypeEvenement.RESULTATS_MUTABILITE, {
+        evaluationId: state.mutabilityResult.evaluationId || undefined,
+        identifiantCadastral: state.identifiantSite || undefined,
+      });
       // Initialisation unique au montage (garde hasInitializedRef) : setState intentionnel
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setMutabilityData(state.mutabilityResult);
       sendIframeMessages(state.mutabilityResult);
     } else {
+      // Calcul asynchrone : le tracking est fait dans calculateMutability une fois l'evaluationId disponible
       calculateMutability();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/ui/src/shared/components/layout/Footer.tsx
+++ b/apps/ui/src/shared/components/layout/Footer.tsx
@@ -27,12 +27,17 @@ export function Footer() {
           <div className="fr-footer__bottom">
             <ul className="fr-footer__bottom-list">
               <li className="fr-footer__bottom-item" key="mentions-legales">
-                <a className="fr-footer__bottom-link" href="/mentions-legales">
+                <a className="fr-footer__bottom-link" href={ROUTES.MENTIONS_LEGALES}>
                   Mentions légales
                 </a>
               </li>
+              <li className="fr-footer__bottom-item" key="donnees-personnelles">
+                <a className="fr-footer__bottom-link" href={ROUTES.POLITIQUE_CONFIDENTIALITE}>
+                  Données personnelles
+                </a>
+              </li>
               <li className="fr-footer__bottom-item" key="accessibilite">
-                <a className="fr-footer__bottom-link" href="/accessibilite">
+                <a className="fr-footer__bottom-link" href={ROUTES.ACCESSIBILITE}>
                   Accessibilité : non conforme
                 </a>
               </li>

--- a/apps/ui/src/shared/components/layout/Footer.tsx
+++ b/apps/ui/src/shared/components/layout/Footer.tsx
@@ -33,7 +33,7 @@ export function Footer() {
               </li>
               <li className="fr-footer__bottom-item" key="donnees-personnelles">
                 <a className="fr-footer__bottom-link" href={ROUTES.POLITIQUE_CONFIDENTIALITE}>
-                  Données personnelles
+                  Politique de confidentialité
                 </a>
               </li>
               <li className="fr-footer__bottom-item" key="accessibilite">

--- a/apps/ui/src/shared/config/map-layers.config.ts
+++ b/apps/ui/src/shared/config/map-layers.config.ts
@@ -3,6 +3,8 @@
  * Utilise les flux WMTS de la Géoplateforme : https://data.geopf.fr/wmts
  */
 
+import { STORAGE_KEYS } from "./storage-keys.config";
+
 /** Type pour les couches de tuiles individuelles */
 export type TileLayerType = "plan" | "orthophotos" | "cadastre";
 
@@ -77,7 +79,7 @@ export const DEFAULT_MAP_LAYER: MapLayerType = "tous";
 /**
  * Clés de stockage localStorage pour la persistance des choix
  */
-export const MAP_LAYER_STORAGE_KEY = "mutafriches:map-layer";
+export const MAP_LAYER_STORAGE_KEY = STORAGE_KEYS.MAP_LAYER;
 
 /** Liste ordonnée des couches de tuiles (pour le mode "tous") */
 export const TILE_LAYERS: TileLayerType[] = ["orthophotos", "plan", "cadastre"];

--- a/apps/ui/src/shared/config/routes.config.ts
+++ b/apps/ui/src/shared/config/routes.config.ts
@@ -25,6 +25,11 @@ export const ROUTES = {
   // Statut technique
   DONNEES_EXTERNES: "/donnees-externes",
 
+  // Pages légales
+  MENTIONS_LEGALES: "/mentions-legales",
+  POLITIQUE_CONFIDENTIALITE: "/politique-de-confidentialite",
+  ACCESSIBILITE: "/accessibilite",
+
   // Pages de test
   TESTS: "/tests",
   TEST_MUTABILITE: "/test/algorithme",

--- a/apps/ui/src/shared/config/storage-keys.config.ts
+++ b/apps/ui/src/shared/config/storage-keys.config.ts
@@ -1,0 +1,28 @@
+/**
+ * Clés centralisées de stockage navigateur (localStorage / sessionStorage).
+ *
+ * Convention pour toute NOUVELLE clé : préfixe "mutafriches" + séparateur underscore,
+ * soit `mutafriches_<domaine>_<cle>`. Éviter le ":" (interprété comme placeholder JDBC
+ * côté Metabase) et le "-".
+ *
+ * IMPORTANT : ne jamais renommer une clé déjà déployée — cela orpheline les valeurs
+ * stockées chez les utilisateurs (parcours en cours, identifiant visiteur, préférences).
+ * Les clés "héritées" ci-dessous ne respectent pas la convention mais sont gelées à ce titre.
+ */
+export const STORAGE_KEYS = {
+  // Tracking / analytics (sessionStorage) — conforme
+  SOURCE: "mutafriches_source",
+  REF: "mutafriches_ref",
+
+  // Identifiant visiteur anonyme persistant (localStorage) — conforme, cf. ADR-0018
+  VISITOR_ID: "mutafriches_visitor_id",
+
+  // État du formulaire (localStorage) — hérité (séparateur "-"), gelé
+  FORM_STATE: "mutafriches-form-state",
+
+  // Préférence de fond de carte (localStorage) — hérité (séparateur ":"), gelé
+  MAP_LAYER: "mutafriches:map-layer",
+
+  // Sites personnalisés CCI 92 (localStorage) — hérité (sans préfixe), gelé
+  CCI92_CUSTOM_SITES: "cci92-custom-sites",
+} as const;

--- a/apps/ui/src/shared/form/FormContext.types.ts
+++ b/apps/ui/src/shared/form/FormContext.types.ts
@@ -1,5 +1,6 @@
 import { EnrichissementOutputDto, MutabiliteOutputDto } from "@mutafriches/shared-types";
 import { ParcelleUiModel } from "../types/parcelle.models";
+import { STORAGE_KEYS } from "../config/storage-keys.config";
 
 export interface FormState {
   // Étape 1 - Données d'enrichissement
@@ -40,7 +41,7 @@ export interface FormContextType {
   resetForm: () => void;
 }
 
-export const STORAGE_KEY = "mutafriches-form-state";
+export const STORAGE_KEY = STORAGE_KEYS.FORM_STATE;
 
 export const initialState: FormState = {
   currentStep: 1,

--- a/apps/ui/src/shared/hooks/useEventTracking.ts
+++ b/apps/ui/src/shared/hooks/useEventTracking.ts
@@ -8,6 +8,7 @@ import {
 } from "@mutafriches/shared-types";
 import { useIframe, useIsIframeMode } from "../iframe/useIframe";
 import { evenementsService } from "../services/api/api.evenements.service";
+import { STORAGE_KEYS } from "../config/storage-keys.config";
 
 export function useEventTracking() {
   const isIframeMode = useIsIframeMode();
@@ -20,12 +21,12 @@ export function useEventTracking() {
     const refParam = urlParams.get("ref");
 
     // Stocker en sessionStorage si présent dans l'URL
-    if (sourceParam) sessionStorage.setItem("mutafriches_source", sourceParam);
-    if (refParam) sessionStorage.setItem("mutafriches_ref", refParam);
+    if (sourceParam) sessionStorage.setItem(STORAGE_KEYS.SOURCE, sourceParam);
+    if (refParam) sessionStorage.setItem(STORAGE_KEYS.REF, refParam);
 
     // Récupérer depuis sessionStorage
-    const source = sessionStorage.getItem("mutafriches_source");
-    const ref = sessionStorage.getItem("mutafriches_ref");
+    const source = sessionStorage.getItem(STORAGE_KEYS.SOURCE);
+    const ref = sessionStorage.getItem(STORAGE_KEYS.REF);
 
     return { source, ref };
   }, []);

--- a/apps/ui/src/shared/iframe/IframeProvider.tsx
+++ b/apps/ui/src/shared/iframe/IframeProvider.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo } from "react";
 import { DEFAULT_IFRAME_CONTEXT, INTEGRATORS } from "./IframeContext.constants";
 import { IframeContext } from "./IframeContext";
+import { STORAGE_KEYS } from "../config/storage-keys.config";
 
 interface IframeProviderProps {
   children: React.ReactNode;
@@ -26,24 +27,24 @@ export function IframeProvider({ children }: IframeProviderProps) {
     // Gérer le tracking source/ref
     if (integratorParam && INTEGRATORS[integratorParam]) {
       // Mode iframe : stocker dans sessionStorage
-      sessionStorage.setItem("mutafriches_source", integratorParam);
+      sessionStorage.setItem(STORAGE_KEYS.SOURCE, integratorParam);
       const refParam = params.get("ref") || `iframe-${integratorParam}`;
-      sessionStorage.setItem("mutafriches_ref", refParam);
+      sessionStorage.setItem(STORAGE_KEYS.REF, refParam);
     } else {
       // Mode standalone sans intégrateur
       const sourceParam = params.get("source");
       const refParam = params.get("ref");
 
       if (sourceParam) {
-        sessionStorage.setItem("mutafriches_source", sourceParam);
+        sessionStorage.setItem(STORAGE_KEYS.SOURCE, sourceParam);
       } else {
-        sessionStorage.removeItem("mutafriches_source");
+        sessionStorage.removeItem(STORAGE_KEYS.SOURCE);
       }
 
       if (refParam) {
-        sessionStorage.setItem("mutafriches_ref", refParam);
+        sessionStorage.setItem(STORAGE_KEYS.REF, refParam);
       } else {
-        sessionStorage.removeItem("mutafriches_ref");
+        sessionStorage.removeItem(STORAGE_KEYS.REF);
       }
     }
 

--- a/apps/ui/src/shared/services/api/api.evaluation.service.ts
+++ b/apps/ui/src/shared/services/api/api.evaluation.service.ts
@@ -8,6 +8,7 @@ import { apiClient } from "./api.client";
 import { API_CONFIG } from "./api.config";
 import { ApiError } from "./api.types";
 import type { CalculerMutabiliteOptions } from "./api.types";
+import { getOrCreateVisitorId } from "./api.utils";
 
 class EvaluationService {
   /**
@@ -50,9 +51,11 @@ class EvaluationService {
       }
     }
 
-    return apiClient.post<MutabiliteOutputDto>(API_CONFIG.endpoints.evaluation.calculer, input, {
-      params,
-    });
+    return apiClient.post<MutabiliteOutputDto>(
+      API_CONFIG.endpoints.evaluation.calculer,
+      { ...input, visitorId: getOrCreateVisitorId() },
+      { params },
+    );
   }
 
   /**

--- a/apps/ui/src/shared/services/api/api.evenements.service.ts
+++ b/apps/ui/src/shared/services/api/api.evenements.service.ts
@@ -2,20 +2,22 @@ import type { EvenementInputDto } from "@mutafriches/shared-types";
 import { apiClient } from "./api.client";
 import { API_CONFIG } from "./api.config";
 import type { ApiCallOptions } from "./api.types";
-import { generateSessionId } from "./api.utils";
+import { generateSessionId, getOrCreateVisitorId } from "./api.utils";
 
 class EvenementsService {
   private sessionId: string;
+  private visitorId: string;
 
   constructor() {
     this.sessionId = generateSessionId();
+    this.visitorId = getOrCreateVisitorId();
   }
 
   /**
    * Enregistrer un événement utilisateur
    */
   async enregistrerEvenement(
-    input: Omit<EvenementInputDto, "sessionId">,
+    input: Omit<EvenementInputDto, "sessionId" | "visitorId">,
     options?: ApiCallOptions,
   ): Promise<void> {
     try {
@@ -34,6 +36,7 @@ class EvenementsService {
         {
           ...input,
           sessionId: this.sessionId,
+          visitorId: this.visitorId,
         },
         { params },
       );

--- a/apps/ui/src/shared/services/api/api.utils.ts
+++ b/apps/ui/src/shared/services/api/api.utils.ts
@@ -1,3 +1,4 @@
+import { STORAGE_KEYS } from "../../config/storage-keys.config";
 import type { ApiError, ApiErrorResponse } from "./api.types";
 
 /**
@@ -6,9 +7,6 @@ import type { ApiError, ApiErrorResponse } from "./api.types";
 export const generateSessionId = (): string => {
   return `session-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 };
-
-/** Clé localStorage de l'identifiant visiteur anonyme */
-const VISITOR_ID_STORAGE_KEY = "mutafriches_visitor_id";
 
 /** Identifiant visiteur en mémoire si localStorage indisponible (navigation privée, storage tiers bloqué) */
 let visitorIdMemoryFallback: string | undefined;
@@ -27,10 +25,10 @@ const genererUuid = (): string => {
  */
 export const getOrCreateVisitorId = (): string => {
   try {
-    const existant = window.localStorage.getItem(VISITOR_ID_STORAGE_KEY);
+    const existant = window.localStorage.getItem(STORAGE_KEYS.VISITOR_ID);
     if (existant) return existant;
     const nouveau = genererUuid();
-    window.localStorage.setItem(VISITOR_ID_STORAGE_KEY, nouveau);
+    window.localStorage.setItem(STORAGE_KEYS.VISITOR_ID, nouveau);
     return nouveau;
   } catch {
     // localStorage indisponible : repli en mémoire pour la durée de la session

--- a/apps/ui/src/shared/services/api/api.utils.ts
+++ b/apps/ui/src/shared/services/api/api.utils.ts
@@ -1,10 +1,44 @@
 import type { ApiError, ApiErrorResponse } from "./api.types";
 
 /**
- * Génère un ID de session unique
+ * Génère un ID de session unique (par chargement d'app, non persisté)
  */
 export const generateSessionId = (): string => {
   return `session-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+};
+
+/** Clé localStorage de l'identifiant visiteur anonyme */
+const VISITOR_ID_STORAGE_KEY = "mutafriches_visitor_id";
+
+/** Identifiant visiteur en mémoire si localStorage indisponible (navigation privée, storage tiers bloqué) */
+let visitorIdMemoryFallback: string | undefined;
+
+/** Génère un UUID anonyme, avec repli si crypto.randomUUID indisponible */
+const genererUuid = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(16)}-${Math.random().toString(16).substring(2, 10)}`;
+};
+
+/**
+ * Récupère (ou crée) un identifiant visiteur anonyme stable entre visites.
+ * Persisté en localStorage ; repli en mémoire si le storage est inaccessible.
+ */
+export const getOrCreateVisitorId = (): string => {
+  try {
+    const existant = window.localStorage.getItem(VISITOR_ID_STORAGE_KEY);
+    if (existant) return existant;
+    const nouveau = genererUuid();
+    window.localStorage.setItem(VISITOR_ID_STORAGE_KEY, nouveau);
+    return nouveau;
+  } catch {
+    // localStorage indisponible : repli en mémoire pour la durée de la session
+    if (!visitorIdMemoryFallback) {
+      visitorIdMemoryFallback = genererUuid();
+    }
+    return visitorIdMemoryFallback;
+  }
 };
 
 /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 
 - **[Module Enrichissement](./enrichissement.md)** - Collecte automatique des données via APIs externes
 - **[Algorithme d'Évaluation](./evaluation-mutabilite.md)** - Calcul des indices de mutabilité
+- **[Tracking & Analytics](./analytics-tracking.md)** - Événements, session vs utilisateur, requêtes Metabase
 
 ### Pour les intégrateurs
 

--- a/docs/adr/0018-identifiant-visiteur-anonyme-persistant.md
+++ b/docs/adr/0018-identifiant-visiteur-anonyme-persistant.md
@@ -1,0 +1,69 @@
+# ADR-0018 : Identifiant visiteur anonyme persistant pour la récurrence cross-visite
+
+**Date** : 2026-06-17
+**Statut** : Accepté
+
+## Contexte
+
+Le besoin analytique « part des utilisateurs récurrents (>= 3 simulations abouties) et leur provenance standalone vs Bénéfriches » n'était pas mesurable avec le modèle de données existant :
+
+- `evaluations.utilisateur_id` existe en base mais n'a jamais été alimenté par `EvaluationRepository.save()` (toujours `NULL`).
+- Le `session_id` des événements (`evenements_utilisateur`) est généré côté UI par `generateSessionId()` (`session-${Date.now()}-${random}`) à l'instanciation du service, **non persisté** : il identifie un chargement d'application (une visite), pas une personne dans la durée.
+- L'événement `resultats_mutabilite` (la « simulation aboutie ») était émis au montage sans `evaluationId` (colonne `evaluation_id` à `NULL` sur 100 % des événements observés), ce qui empêchait de dédoublonner les simulations.
+
+Mutafriches n'a aucune authentification : il faut un proxy anonyme et stable d'un visiteur pour mesurer la récurrence réelle entre visites.
+
+## Décision
+
+> Nous introduisons un identifiant visiteur anonyme (UUID) persisté en `localStorage` côté UI, propagé aux événements et aux évaluations, pour mesurer la récurrence cross-visite sans authentification.
+
+- **UI** : `getOrCreateVisitorId()` génère un UUID (`crypto.randomUUID`, avec repli) stocké sous la clé `mutafriches_visitor_id` ; repli en mémoire si `localStorage` est indisponible (navigation privée, storage tiers bloqué en iframe).
+- **Événements** : nouvelle colonne `evenements_utilisateur.visitor_id` (+ index `idx_visitor_id`), alimentée à chaque événement.
+- **Évaluations** : le `visitorId` transite dans `CalculerMutabiliteInputDto` et est écrit dans la colonne **existante** `evaluations.utilisateur_id` (réutilisation, donc aucune migration sur `evaluations`).
+- **Volet associé** : l'événement `resultats_mutabilite` porte désormais `evaluationId`, pour dédoublonner les simulations en analytics.
+
+## Options envisagées
+
+### Option A — UUID anonyme en localStorage + réutilisation de `utilisateur_id` (retenue)
+
+- Avantages : sans authentification, anonyme (pas de PII), stable entre visites ; aucune migration sur `evaluations` (colonne déjà présente) ; une seule nouvelle colonne (`visitor_id` sur les événements).
+- Inconvénients : `localStorage` effacé ou bloqué => nouvel identifiant (sous-estimation possible de la récurrence) ; détourne sémantiquement `utilisateur_id` (qui n'est pas un compte authentifié).
+
+### Option B — Authentification utilisateur complète
+
+- Avantages : identité fiable, récurrence exacte, ouvre d'autres fonctionnalités (espace personnel).
+- Inconvénients : très lourd (login, sessions, RGPD renforcé) ; hors périmètre d'un outil public sans compte ; surdimensionné pour un simple besoin de mesure.
+
+### Option C — Colonne `visitor_id` dédiée sur `evaluations`, en gardant `utilisateur_id` pour une future auth
+
+- Avantages : séparation claire entre identité anonyme et future authentification.
+- Inconvénients : migration supplémentaire sur `evaluations` ; `utilisateur_id` reste mort à court terme ; complexité non justifiée tant qu'aucune auth n'est planifiée.
+
+## Conséquences
+
+### Positives
+
+- La récurrence cross-visite et la ventilation provenance (standalone / Bénéfriches) deviennent mesurables en SQL/Metabase via `visitor_id`.
+- `evaluation_id` désormais présent sur `resultats_mutabilite` => dédoublonnage fiable des simulations.
+- Coût base de données minimal (une colonne + un index), aucune migration sur `evaluations`.
+
+### Négatives / Risques
+
+- Identifiant lié au navigateur : effacement du storage, multi-appareils ou navigation privée fragmentent la mesure.
+- RGPD : identifiant anonyme sans PII, sans usage publicitaire ni cross-site ; durée de conservation à documenter et mention à valider dans la politique de confidentialité.
+- Les statistiques de récurrence ne sont exploitables qu'après accumulation de données post-déploiement (les évaluations/événements antérieurs n'ont pas de `visitor_id`).
+
+### Migration (si applicable)
+
+- Migration `0024_strong_wolfpack.sql` : `ALTER TABLE evenements_utilisateur ADD COLUMN visitor_id` + `CREATE INDEX idx_visitor_id` (idempotent `IF NOT EXISTS`, le snapshot Drizzle ayant divergé des migrations 0021-0023 écrites à la main).
+- Aucune migration sur `evaluations` (réutilisation de `utilisateur_id`).
+- Requête Metabase cible : grouper par `visitor_id` au lieu de `session_id`, décompte par `COUNT(DISTINCT evaluation_id)`.
+
+## Liens
+
+- Schémas : `apps/api/src/shared/database/schemas/evenements.schema.ts`, `apps/api/src/shared/database/schemas/evaluations.schema.ts`
+- API : `apps/api/src/evaluation/repositories/evaluation.repository.ts`, `apps/api/src/evaluation/services/orchestrateur.service.ts`, `apps/api/src/evenements/services/evenement.service.ts`
+- UI : `apps/ui/src/shared/services/api/api.utils.ts`, `apps/ui/src/shared/services/api/api.evenements.service.ts`, `apps/ui/src/shared/services/api/api.evaluation.service.ts`, `apps/ui/src/features/resultats/pages/ResultatsPage.tsx`
+- Types : `packages/shared-types/src/evenements/dto/evenement-input.dto.ts`, `packages/shared-types/src/evaluation/dto/calculer-mutabilite-input.dto.ts`
+- ADR liés : ADR-0012 (tracking source vs intégrateur), ADR-0008 (intégration iframe postMessage)
+- Migration : `apps/api/src/shared/database/migrations/0024_strong_wolfpack.sql`

--- a/docs/analytics-tracking.md
+++ b/docs/analytics-tracking.md
@@ -1,0 +1,99 @@
+# Tracking & analytics
+
+> Comment Mutafriches mesure l'usage (événements, sessions, utilisateurs) et comment interpréter les statistiques côté Metabase.
+
+## Modèle de données
+
+Les événements utilisateur sont stockés dans la table `evenements_utilisateur` (schéma : `apps/api/src/shared/database/schemas/evenements.schema.ts`). Champs utiles pour l'analyse :
+
+| Colonne | Rôle |
+|---------|------|
+| `type_evenement` | Étape du parcours (`resultats_mutabilite` = simulation aboutie, etc.) |
+| `session_id` | Identifiant d'une **visite** (voir ci-dessous) |
+| `visitor_id` | Identifiant d'un **utilisateur** anonyme persistant (voir ci-dessous) |
+| `evaluation_id` | Lien vers l'évaluation calculée (permet de dédoublonner les simulations) |
+| `mode_utilisation` | `standalone` ou `iframe` |
+| `integrateur` | Provenance (`benefriches`, hostname, ...) |
+
+Les évaluations persistées (`evaluations`) portent aussi `source_utilisation`, `integrateur`, `utilisateur_id` (réutilisé pour le `visitor_id`) et `fiabilite`.
+
+## Session vs utilisateur : la distinction clé
+
+C'est la nuance qui change l'interprétation de toutes les stats de récurrence.
+
+| | **Session** | **Utilisateur (visiteur)** |
+|---|---|---|
+| Représente | Une visite / période d'activité continue | Une personne, à travers le temps |
+| Durée de vie | Éphémère : régénérée à chaque chargement de l'app (un F5 = nouvelle session) | Persistante : survit aux rechargements et aux visites |
+| Stockage | En mémoire, non persisté | `localStorage` du navigateur |
+| Source dans le code | `generateSessionId()` → `session-${Date.now()}-${random}` | `getOrCreateVisitorId()` → UUID persisté sous la clé `mutafriches_visitor_id` |
+
+Conséquence : mesurer la récurrence **par session** sous-estime le nombre de personnes réellement récurrentes — une même personne qui revient compte comme plusieurs sessions.
+
+### Comment garantir « le même utilisateur » ?
+
+Il faut un identifiant **stocké côté client qui survit aux rechargements et aux visites**. Par ordre de robustesse :
+
+1. **`localStorage` (approche retenue)** — un UUID anonyme généré une fois, relu à chaque visite. Standard pour de l'analytics anonyme sans compte. Le mot-clé qui sépare des deux notions : *persistant* (vs la session, en mémoire).
+2. **Cookie persistant** — équivalent mais renvoyé au serveur à chaque requête ; plus exposé au RGPD.
+3. **Authentification (login)** — seul moyen *certain* (ID lié à un compte, pas à un navigateur), mais hors périmètre d'un outil public sans compte.
+
+### Limites — un « même utilisateur » reste une approximation
+
+Sans login, l'égalité « 1 identifiant = 1 personne » casse dans ces cas :
+
+- **Multi-appareils** (mobile + bureau) → 2 identifiants.
+- **Multi-navigateurs** (Chrome / Firefox ne partagent pas le `localStorage`).
+- **Navigation privée** → identifiant éphémère ou bloqué (repli en mémoire).
+- **Vidage du cache / suppression des données du site** → nouvel identifiant.
+- **Iframe (Bénéfriches)** : `localStorage` par-origine — OK car servie depuis le domaine Mutafriches, mais certains navigateurs restreignent le storage tiers en cross-site.
+
+En résumé : `visitor_id` transforme « par visite » en « par navigateur » — bien meilleur que la session, mais toujours une sous-estimation par rapport à « par personne ». Seul un compte authentifié supprime cette marge d'erreur.
+
+## État de la mesure
+
+- **Provisoire (avant déploiement du `visitor_id`)** : la récurrence est mesurée par `session_id` (une visite). Les chiffres sont une **borne basse indicative**.
+- **Cible (après déploiement)** : récurrence mesurée par `visitor_id` (un navigateur), décompte des simulations via `COUNT(DISTINCT evaluation_id)`.
+
+Détails de la décision et du périmètre technique : voir [ADR-0018](./adr/0018-identifiant-visiteur-anonyme-persistant.md).
+
+## Requêtes Metabase de référence
+
+### Part des utilisateurs récurrents par provenance — version provisoire (par session)
+
+```sql
+WITH simulations AS (
+  SELECT
+    session_id,
+    COUNT(*) AS nb_simulations,
+    MAX(CASE WHEN integrateur ILIKE '%benefriches%' THEN 1 ELSE 0 END) AS est_benefriches,
+    MAX(CASE WHEN mode_utilisation = 'iframe' THEN 1 ELSE 0 END)       AS est_iframe
+  FROM evenements_utilisateur
+  WHERE type_evenement = 'resultats_mutabilite'
+    AND session_id IS NOT NULL
+  GROUP BY session_id
+),
+recurrents AS (
+  SELECT session_id, nb_simulations,
+    CASE
+      WHEN est_benefriches = 1 THEN 'Bénéfriches'
+      WHEN est_iframe = 1      THEN 'Autre intégrateur (iframe)'
+      ELSE                          'Standalone'
+    END AS provenance
+  FROM simulations
+  WHERE nb_simulations >= 3
+)
+SELECT provenance,
+       COUNT(*) AS nb_utilisateurs_recurrents,
+       ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 1) AS pct_utilisateurs,
+       SUM(nb_simulations) AS total_simulations
+FROM recurrents
+GROUP BY provenance
+ORDER BY nb_utilisateurs_recurrents DESC;
+```
+
+### Version cible (par visiteur, après déploiement)
+
+Remplacer `session_id` par `visitor_id` et `COUNT(*)` par `COUNT(DISTINCT evaluation_id)`.
+
+> Note Metabase/PostgreSQL : ne pas nommer un CTE `analyse` (`ANALYSE` est un mot réservé). Préférer `jsonb_exists(...)` à l'opérateur `?` (interprété comme un placeholder JDBC).

--- a/docs/integration/react/src/App.jsx
+++ b/docs/integration/react/src/App.jsx
@@ -340,7 +340,7 @@ function App() {
               </li>
               <li className="fr-footer__bottom-item">
                 <a id="footer__bottom-link-7" href="#" className="fr-footer__bottom-link">
-                  Données personnelles
+                  Politique de confidentialité
                 </a>
               </li>
               <li className="fr-footer__bottom-item">

--- a/packages/shared-types/src/evaluation/dto/calculer-mutabilite-input.dto.ts
+++ b/packages/shared-types/src/evaluation/dto/calculer-mutabilite-input.dto.ts
@@ -15,4 +15,10 @@ export interface CalculerMutabiliteInputDto {
    * Données complémentaires saisies par l'utilisateur
    */
   donneesComplementaires: DonneesComplementairesInputDto;
+
+  /**
+   * Identifiant visiteur anonyme persistant (localStorage), stable entre visites.
+   * Persisté dans evaluations.utilisateur_id pour mesurer la récurrence cross-visite.
+   */
+  visitorId?: string;
 }

--- a/packages/shared-types/src/evenements/dto/evenement-input.dto.ts
+++ b/packages/shared-types/src/evenements/dto/evenement-input.dto.ts
@@ -33,6 +33,8 @@ export interface EvenementInputDto {
   identifiantCadastral?: string;
   donnees?: EvenementDonnees;
   sessionId?: string;
+  /** Identifiant visiteur anonyme persistant (localStorage), stable entre visites */
+  visitorId?: string;
   sourceCampagne?: string;
   ref?: string;
   integrateur?: string;


### PR DESCRIPTION
Persiste un visitor_id (localStorage) propagé aux événements et évaluations pour mesurer la récurrence cross-visite sans login.

Ajout des 3 pages mentions légales / accessibilité et politique de confidentialité

Ajout d'un mécanisme de centralisation des clés localStorage